### PR TITLE
Bump MSRV and `reqwest` dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,11 @@ jobs:
   build:
     strategy:
       matrix:
-        toolchain: [ stable, beta, 1.63.0 ] # 1.63.0 is current MSRV for vss-client
+        toolchain: [ stable, beta, 1.75.0 ] # 1.75.0 is current MSRV for vss-client
         include:
           - toolchain: stable
             check-fmt: true
-          - toolchain: 1.63.0
+          - toolchain: 1.75.0
             msrv: true
     runs-on: ubuntu-latest
     steps:
@@ -25,10 +25,7 @@ jobs:
       - name: Pin packages to allow for MSRV
         if: matrix.msrv
         run: |
-            cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
-            cargo update -p regex --precise "1.9.6" --verbose # regex 1.10.0 requires rustc 1.65.0
-            cargo update -p tokio --precise "1.38.1" --verbose # tokio v1.39.0 requires rustc 1.70 or newer
-            cargo update -p tokio-util --precise "0.7.11" --verbose # tokio-util v0.7.12 requires rustc 1.70 or newer
+          cargo update -p idna_adapter --precise 1.1.0 # This has us use `unicode-normalization` which has a more conservative MSRV
       - name: Build on Rust ${{ matrix.toolchain }}
         run: cargo build --verbose --color always
       - name: Check formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ lnurl-auth = ["dep:bitcoin", "dep:url", "dep:serde", "dep:serde_json", "reqwest/
 
 [dependencies]
 prost = "0.11.6"
-reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tokio = { version = "1", default-features = false, features = ["time"] }
 rand = "0.8.5"
 async-trait = "0.1.77"
 bitcoin = { version = "0.32.2", default-features = false, features = ["std", "rand-std"], optional = true }
 url = { version = "2.5.0", default-features = false, optional = true }
-base64 = { version = "0.21.7", default-features = false}
+base64 = { version = "0.22", default-features = false}
 serde = { version = "1.0.196", default-features = false, features = ["serde_derive"], optional = true }
 serde_json = { version = "1.0.113", default-features = false, optional = true }
 
@@ -32,7 +32,7 @@ bitcoin_hashes = "0.14.0"
 
 [target.'cfg(genproto)'.build-dependencies]
 prost-build = { version = "0.11.3" }
-reqwest =  { version = "0.11.13", default-features = false, features = ["rustls-tls", "blocking"] }
+reqwest =  { version = "0.12", default-features = false, features = ["rustls-tls", "blocking"] }
 
 [dev-dependencies]
 mockito = "0.28.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,10 @@ reqwest =  { version = "0.11.13", default-features = false, features = ["rustls-
 mockito = "0.28.0"
 proptest = "1.1.0"
 tokio = { version = "1.22.0", features = ["macros"]}
+
+[lints.rust.unexpected_cfgs]
+level = "forbid"
+# When adding a new cfg attribute, ensure that it is added to this list.
+check-cfg = [
+	"cfg(genproto)",
+]

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ and manage the essential state required for Lightning Network (LN) operations.
 Learn more [here](https://github.com/lightningdevkit/vss-server/blob/main/README.md).
 
 ## MSRV
-The Minimum Supported Rust Version (MSRV) is currently 1.63.0.
+The Minimum Supported Rust Version (MSRV) is currently 1.75.0.


### PR DESCRIPTION
We bump the MSRV to 1.75.0 as most of our HTTP dependencies already require this, and we already require it for `lightning-transaction-sync` / LDK Node.

As we can do this then, we bump the `reqwest` dependency to 0.12 (which is nice as most other projects have by now, allowing us to not keep multiple versions in the tree).